### PR TITLE
Remove problem executables for signing on macOS

### DIFF
--- a/motion-fabric.gemspec
+++ b/motion-fabric.gemspec
@@ -2,9 +2,9 @@
 
 Gem::Specification.new do |spec|
   spec.name        = 'motion-fabric'
-  spec.version     = '0.7'
+  spec.version     = '0.8'
   spec.description = 'Fabric in your RubyMotion applications.'
-  spec.summary     = 'motion-fabric allows you to easily integrate Fabric 
+  spec.summary     = 'motion-fabric allows you to easily integrate Fabric
                       in your RubyMotion applications.'
   spec.author      = 'HipByte'
   spec.email       = 'info@hipbyte.com'


### PR DESCRIPTION
For some reason, the Crashlytics and Fabric frameworks come with exectuables
in the actual Framework folder.  The framework cannot be signed properly on macOS.

An example error:

```
Codesign Verifying that app is completely signed
...
./build/MacOSX-10.12-Release/Sample.app/Contents/MacOS/Sample: unsealed contents present in the root directory of an embedded framework
In subcomponent: /.../build/MacOSX-10.12-Release/Sample.app/Contents/Frameworks/Crashlytics.framework
  Codesign !!! Signature Failed !!!
```

So before signing, remove those extra files.  Signature is then properly created and verified.

I did not notice a similar issue on iOS